### PR TITLE
le-potato: Disable GLES lighting

### DIFF
--- a/meta-doom-demo/recipes-games/zdoom/zdoom-autolaunch/libretech-cc/zdoom.ini
+++ b/meta-doom-demo/recipes-games/zdoom/zdoom-autolaunch/libretech-cc/zdoom.ini
@@ -3,6 +3,9 @@ gl_es=true
 vid_preferbackend=2
 fullscreen=1
 
+# Disable lighting. It doesn't render properly on this hardware
+vid_rendermode=3
+
 [Chex.Player]
 name=Le Potato
 # Light Gray


### PR DESCRIPTION
Lighting causes rendering glitches on this hardware, so disable it (we don't really need it anyway)